### PR TITLE
feat: Use GNU/POSIX-style argument syntax conventions for CLI flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,34 +39,34 @@ pub fn get_args() -> DCPResult<Config> {
                 .required(true)
         )
         .arg(
-            Arg::with_name("download_path")
-                .value_name("DOWNLOAD_PATH")
+            Arg::with_name("download-path")
+                .value_name("DOWNLOAD-PATH")
                 .help("Where the image contents should be saved on the filesystem")
                 .default_value(".")
                 .short("d")
-                .long("download_path")
+                .long("download-path")
         )
         .arg(
-            Arg::with_name("content_path")
-                .value_name("CONTENT_PATH")
+            Arg::with_name("content-path")
+                .value_name("CONTENT-PATH")
                 .help("Where in the container filesystem the content to extract is")
                 .short("p")
                 .default_value("/")
-                .long("content_path")
+                .long("content-path")
         )
         .arg(
-            Arg::with_name("write_to_stdout")
-                .value_name("WRITE_TO_STDOUT")
+            Arg::with_name("write-to-stdout")
+                .value_name("WRITE-TO-STDOUT")
                 .help("Whether to write to stdout instead of the filesystem")
                 .takes_value(false)
                 .short("w")
-                .long("write_to_stdout")
+                .long("write-to-stdout")
         ).get_matches();
 
     let image = matches.value_of("image").unwrap().to_string();
-    let download_path = matches.value_of("download_path").unwrap().to_string();
-    let content_path = matches.value_of("content_path").unwrap().to_string();
-    let write_to_stdout = matches.is_present("write_to_stdout");
+    let download_path = matches.value_of("download-path").unwrap().to_string();
+    let content_path = matches.value_of("content-path").unwrap().to_string();
+    let write_to_stdout = matches.is_present("write-to-stdout");
 
     if write_to_stdout {
         return Err(Box::new(DCPError::new("error: writing to stdout is not currently implemented")));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -9,7 +9,7 @@ const TEST_CONTENT_DIR: &str = "/tmp/dcp_test_run";
 const DEFAULT_IMAGE: &str = "quay.io/tyslaton/sample-catalog:v0.0.4";
 const IMAGE_NO_TAG: &str = "quay.io/tyslaton/sample-catalog";
 
-// generate_temp_path takes the constant TEST_CONTENT_DIR and 
+// generate_temp_path takes the constant TEST_CONTENT_DIR and
 // returns a new string with an appended 5 digit string
 fn generate_temp_path() -> String {
     let random_string = thread_rng().gen_range(10000..99999);
@@ -40,7 +40,7 @@ fn accepts_download_path() -> TestResult {
 
     // content_path is defined and succeeds
     Command::cargo_bin(PRG)?
-        .args(&["--download_path", path])
+        .args(&["--download-path", path])
         .args(&[DEFAULT_IMAGE])
         .assert()
         .success();
@@ -59,8 +59,8 @@ fn accepts_content_path() -> TestResult {
 
     // content_path is defined and succeeds
     Command::cargo_bin(PRG)?
-        .args(&["--download_path", path])
-        .args(&["--content_path", content_path, DEFAULT_IMAGE])
+        .args(&["--download-path", path])
+        .args(&["--content-path", content_path, DEFAULT_IMAGE])
         .assert()
         .success();
 
@@ -78,14 +78,14 @@ fn accepts_image() -> TestResult {
 
     // image is defined and succeeds
     Command::cargo_bin(PRG)?
-        .args(&["--download_path", path])
+        .args(&["--download-path", path])
         .args(&[DEFAULT_IMAGE])
         .assert()
         .success();
 
     // image is not defined and fails
     Command::cargo_bin(PRG)?
-        .args(&["--download_path", path])
+        .args(&["--download-path", path])
         .assert()
         .failure();
 
@@ -99,7 +99,7 @@ fn defaults_tag_to_latest() -> TestResult {
 
     // image is defined and succeeds
     Command::cargo_bin(PRG)?
-        .args(&["--download_path", path])
+        .args(&["--download-path", path])
         .args(&[IMAGE_NO_TAG])
         .assert()
         .success();
@@ -114,7 +114,7 @@ fn fails_on_just_tag() -> TestResult {
 
     // image is defined and succeeds
     Command::cargo_bin(PRG)?
-        .args(&["--download_path", path])
+        .args(&["--download-path", path])
         .args(&[":v0.0.4"])
         .assert()
         .failure();


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>