### PR TITLE
feat: add log_level flag and utilize pretty_env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,9 @@ dependencies = [
  "clap",
  "docker-api",
  "futures-util",
+ "log",
  "predicates",
+ "pretty_env_logger",
  "rand",
  "tar",
  "tokio",
@@ -223,6 +225,19 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "filetime"
@@ -431,6 +446,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "hyper"
@@ -729,6 +753,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +770,12 @@ checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -908,6 +948,15 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1126,6 +1175,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ docker-api = "0.9.1"
 tokio = { version = "1.0", features = ["full"] }
 futures-util = "0.3"
 tar = "0.4"
+log = "0.4"
+pretty_env_logger = "0.4"
 
 [dev-dependencies]
 predicates = "2.1.1"


### PR DESCRIPTION
## Summary
Using the `pretty_env_logger` to add some color into the application. Considered using the crate recommended in the issue but thought that using fully-featured logger would make more sense. This entailed a few changes:

1. Introducing the `log` crate and an implementation of it in the form of `pretty_env_logger`.
2. Added a new flag `--log-level` (or `-l` for short) to allow a user to define the level. Defaults to `info`.
3. Updated our `println!()` or `eprintln!()` calls to use structured calls to the `pretty_env_logger` macros.
4. Added some emojis for flavor 🥇 

## Preview
Most of the changes here are visual, so here are a few example of how the CLI looks when running it.

> **Note**: I'm not tied to any of the emojis, feel free to request that they be removed if we're not a fan. That being said, I personally like them!

### Default log level:
The log level by default will be `info` which is intended to just display the essential information.
```
$ dcp quay.io/tyslaton/sample-catalog:v0.0.4 -d /tmp/dcp_test_dir
```
![Screen Shot 2022-07-14 at 9 51 21 PM](https://user-images.githubusercontent.com/54378333/179132817-32109211-7785-4eb8-87e1-ccde438a5d04.png)

### Defined log level:
By defining the log level as `debug` we can see a lot more of the underlying processes taking place.
```
$ dcp quay.io/tyslaton/sample-catalog:v0.0.4 -d /tmp/dcp_test_dir --log-level debug
```
![Screen Shot 2022-07-14 at 9 50 35 PM](https://user-images.githubusercontent.com/54378333/179132649-64ec8da8-3fdd-4f56-853a-a77b618b75e1.png)

### Error output
```
$ dcp quay.io/tyslaton/sample-catalog:v0.0. -d /tmp/dcp_test_dir
```
![Screen Shot 2022-07-14 at 9 51 42 PM](https://user-images.githubusercontent.com/54378333/179132891-2b5c3078-d771-4da8-9b72-6d9cb0e8fb74.png)

Closes https://github.com/exdx/dcp/issues/15
Closes https://github.com/exdx/dcp/issues/3