### PR TITLE
lib: add support for podman container runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,28 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
-  test:
+  e2e-docker:
     needs: build
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - name: Run tests
+      - name: Run e2e tests with docker tests
         run: cargo test --verbose
+
+  e2e-podman:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run podman tests
+        run: |
+          sudo systemctl stop docker
+          sudo systemctl stop docker.socket
+          echo "podman info"
+          podman info
+          systemctl --user enable --now podman.socket
+          cargo test --verbose
+
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "containers-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2ca95f626f7be904f6ee24d0a525e7564c5c99544727229577f707dca42468"
+dependencies = [
+ "chrono",
+ "flate2",
+ "futures-util",
+ "futures_codec",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "mime",
+ "paste",
+ "pin-project 1.0.11",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "containers-api-conn"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,11 +204,13 @@ dependencies = [
  "docker-api",
  "futures-util",
  "log",
+ "podman-api",
  "predicates",
  "pretty_env_logger",
  "rand",
  "tar",
  "tokio",
+ "xdg",
 ]
 
 [[package]]
@@ -191,6 +218,26 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "doc-comment"
@@ -724,6 +771,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "podman-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852a469c27bc8e6a403f1bd73288f241b3e813fe837b749ab87d03ef8f7ca147"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes 1.1.0",
+ "chrono",
+ "containers-api",
+ "flate2",
+ "futures-util",
+ "futures_codec",
+ "log",
+ "paste",
+ "podman-api-stubs",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "podman-api-stubs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2c5fdd235733e79a8570997ef664788a9f877899d0e7ae6e17acbd40b11413"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +913,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -1248,4 +1342,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xdg"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
+dependencies = [
+ "dirs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ tar = "0.4"
 log = "0.4"
 pretty_env_logger = "0.4"
 anyhow = "1.0"
+podman-api = "0.4"
+xdg = "^2.1"
 
 [dev-dependencies]
 predicates = "2.1.1"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,71 @@
+use anyhow::{anyhow, Result};
+use docker_api::Docker;
+use podman_api::Podman;
+use xdg::BaseDirectories;
+
+const DOCKER_SOCKET: &str = "unix:///var/run/docker.sock";
+
+pub struct Runtime {
+    pub docker: Option<docker_api::Docker>,
+    pub podman: Option<podman_api::Podman>,
+}
+
+pub async fn set() -> Option<Runtime> {
+    match Docker::new(DOCKER_SOCKET) {
+        Ok(docker) => {
+            // Use version() as a proxy for socket connection status
+            match docker.version().await {
+                Ok(_) => Some(Runtime {
+                    docker: Some(docker),
+                    podman: None,
+                }),
+                Err(_) => {
+                    // Fallback to podman config
+                    debug!("🔧 docker socket not found: falling back to podman configuration");
+                    let socket = get_podman_socket().ok()?;
+                    match Podman::new(socket) {
+                        // Use version() as a proxy for socket connection status
+                        Ok(podman) => match podman.version().await {
+                            Ok(_) => {
+                                return Some(Runtime {
+                                    docker: None,
+                                    podman: Some(podman),
+                                })
+                            }
+                            Err(_) => {
+                                error!("❌ neither docker or podman sockets were found running on this host");
+                                return None;
+                            }
+                        },
+                        Err(_) => {
+                            error!("❌ unable to create a podman client on the host");
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+        Err(_) => {
+            error!("❌ unable to create a docker client on the host");
+            return None;
+        }
+    }
+}
+
+fn get_podman_socket() -> Result<String> {
+    let base_dirs = BaseDirectories::new()?;
+    if !base_dirs.has_runtime_directory() {
+        return Err(anyhow!("could not find xdg runtime directory"));
+    }
+    let runtime_dir = base_dirs.get_runtime_directory()?;
+    let podman_socket = format!(
+        "{}{}{}",
+        "unix://",
+        runtime_dir.as_path().to_str().unwrap(),
+        "/podman/podman.sock"
+    );
+
+    debug!("🔧 podman socket at {}", podman_socket);
+
+    Ok(podman_socket)
+}


### PR DESCRIPTION
Adds support for podman. Initially I tried to write a completely generic solution, but quickly ran into issues because the methods provided on the container type are functions instead of traits. Going that route would require writing a trait for every function call required by the container type. It seemed like a lot of work. Instead, I took a simpler route and encapsulated both runtimes as part of a custom type. 

Closes #26 

TODO:

- Update documentation to reflect podman as a viable option
- Add e2e tests running on an OS where podman is the only runtime available (fedora?)