### PR TITLE
feat: add support for private docker registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ By default, dcp will copy content to the current directory `.`. For example, let
 try issuing the following command:
 
 ```
-$ dcp tyslaton/sample-catalog:v0.0.4 -p configs
+$ dcp tyslaton/sample-catalog:v0.0.4 -c configs
 ```
 
-This command will copy the `configs` directory (specified via the `-p` flag) from the image to the current directory.
+This command will copy the `configs` directory (specified via the `c` flag) from the image to the current directory.
 
 For further configuration, lets try:
 
 ```
-$ dcp tyslaton/sample-catalog:v0.0.4 -d output -p configs
+$ dcp tyslaton/sample-catalog:v0.0.4 -d output -c configs
 ```
 
 This command pulls down the requested image, only extracting
@@ -76,7 +76,7 @@ locally (specified via the `-d` flag).
 Another example, for copying only the manifests directory:
 
 ```
-$ dcp quay.io/tflannag/bundles:resolveset-v0.0.2 -p manifests
+$ dcp quay.io/tflannag/bundles:resolveset-v0.0.2 -c manifests
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Another example, for copying only the manifests directory:
 $ dcp quay.io/tflannag/bundles:resolveset-v0.0.2 -c manifests
 ```
 
+Lastly, we can reference a private registry by providing a username
+and password (specified via the `-u` and `-p` flags).
+
+```
+$ dcp quay.io/tyslaton/sample-catalog-private:latest -u <username> -p <password>
+```
+
+**Note**: This serves as a convenient way to connect to private 
+registries but is insecure locally as your credentials are saved in
+your shell's history. If you would like to remain completely secure then
+login via `<container_runtime> login` and pull the image locally. `dcp` 
+will then be able to notice the image locally pulled and process it.
+
 ## Testing
 
 If you would like to run the test suite, you just need to run the standard cargo command. This will run all relevant

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn get_args() -> Result<Config> {
             Arg::with_name("content-path")
                 .value_name("CONTENT-PATH")
                 .help("Where in the container filesystem the content to extract is")
-                .short("p")
+                .short("c")
                 .default_value("/")
                 .long("content-path"),
         )


### PR DESCRIPTION
## Summary
This PR adds the ability to specify the username and password to use when authenticating against a registry. It does this by adding two new flags:

* `--username`, `-u`
* `--password`, `-p`

In addition, the `--content-path` short name has been updated to be `-c` (from `-p` as that seems more fitting for `--password`).

## Review Notes
1. This currently only supports writing your username/password to the console. Its fine to have this as is but we should also come up with a better way of using the docker config so that users can do this more securely locally. This is likely a good follow-up.
2. There is the ability for us to add another flag that specifies what server to use but it felt superfluous as it defaults to wherever the image is stored. I'd be happy to update it if we want that.
3. I did not add tests here as the bloat for testing private registries would delay this feature. I'd prefer get this through and worry about that complex testing logic later.

Closes #1 