### PR TITLE
refactor: breakout config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,135 @@
+use anyhow::{anyhow, Result};
+use clap::{App, Arg};
+
+use crate::runtime;
+
+pub const VERSION: &str = "0.4.0";
+
+#[derive(Debug)]
+pub struct Config {
+    // List of images
+    pub image: String,
+    // Where the download files should be saved on the filesystem. Default "."
+    pub download_path: String,
+    // Where the content (files) are in the container filesystem. Default "/"
+    pub content_path: String,
+    // Option to write to stdout instead of the local filesystem.
+    pub write_to_stdout: bool,
+    // What level of logs to output
+    pub log_level: String,
+    // Username for singing into a private registry
+    pub username: String,
+    // Password for signing into a private registry
+    pub password: String,
+    // Force a pull even if the image is present locally
+    pub force_pull: bool,
+    // Specify a custom socket to utilize for the runtime
+    pub socket: String,
+}
+
+pub fn get_args() -> Result<Config> {
+    let matches = App::new("dcp")
+        .version(VERSION)
+        .author("exdx")
+        .about("docker cp made easy")
+        .arg(
+            Arg::with_name("image")
+                .value_name("IMAGE")
+                .help("Container image to extract content from")
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("download-path")
+                .value_name("DOWNLOAD-PATH")
+                .help("Where the image contents should be saved on the filesystem")
+                .default_value(".")
+                .short("d")
+                .long("download-path"),
+        )
+        .arg(
+            Arg::with_name("content-path")
+                .value_name("CONTENT-PATH")
+                .help("Where in the container filesystem the content to extract is")
+                .short("c")
+                .default_value("/")
+                .long("content-path"),
+        )
+        .arg(
+            Arg::with_name("write-to-stdout")
+                .value_name("WRITE-TO-STDOUT")
+                .help("Whether to write to stdout instead of the filesystem")
+                .takes_value(false)
+                .short("w")
+                .long("write-to-stdout"),
+        )
+        .arg(
+            Arg::with_name("username")
+                .value_name("USERNAME")
+                .help("Username used for singing into a private registry.")
+                .short("u")
+                .long("username")
+                .default_value(""),
+
+        )
+        .arg(
+            Arg::with_name("password")
+                .value_name("PASSWORD")
+                .help("Password used for signing into a private registry. * WARNING *: Writing credentials to your terminal is risky. Be sure you are okay with them showing up in your history")
+                .short("p")
+                .long("password")
+                .default_value(""),
+
+        )
+        .arg(
+            Arg::with_name("log-level")
+                .value_name("LOG-LEVEL")
+                .help("What level of logs to output. Accepts: [info, debug, trace, error, warn]")
+                .short("l")
+                .long("log-level")
+                .default_value("debug"),
+        )
+        .arg(
+            Arg::with_name("force-pull")
+                .value_name("FORCE-PULL")
+                .help("Force a pull even if the image is present locally")
+                .takes_value(false)
+                .long("force-pull")
+                .short("f")
+        )
+        .arg(
+            Arg::with_name("socket")
+                .value_name("SOCKET")
+                .help("Specify a custom socket to utilize for the runtime")
+                .long("socket")
+                .short("s")
+                .default_value(runtime::DEFAULT_SOCKET)
+        )
+        .get_matches();
+
+    let image = matches.value_of("image").unwrap().to_string();
+    let download_path = matches.value_of("download-path").unwrap().to_string();
+    let content_path = matches.value_of("content-path").unwrap().to_string();
+    let write_to_stdout = matches.is_present("write-to-stdout");
+    let force_pull = matches.is_present("force-pull");
+    let log_level = matches.value_of("log-level").unwrap().to_string();
+    let socket = matches.value_of("socket").unwrap().to_string();
+    // TODO (tyslaton): Need to come up with a way for this to be extracted from the docker config to be more secure locally.
+    let username = matches.value_of("username").unwrap().to_string();
+    let password = matches.value_of("password").unwrap().to_string();
+
+    if write_to_stdout {
+        return Err(anyhow!("❌ writing to stdout is not currently implemented"));
+    };
+
+    Ok(Config {
+        image,
+        download_path,
+        content_path,
+        write_to_stdout,
+        log_level,
+        username,
+        password,
+        force_pull,
+        socket,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,144 +1,11 @@
 use anyhow::{anyhow, Result};
-use clap::{App, Arg};
 
+pub mod config;
 mod runtime;
 
 extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
-
-pub const VERSION: &str = "0.4.0";
-
-#[derive(Debug)]
-pub struct Config {
-    // List of images
-    image: String,
-    // Where the download files should be saved on the filesystem. Default "."
-    download_path: String,
-    // Where the content (files) are in the container filesystem. Default "/"
-    content_path: String,
-    // Option to write to stdout instead of the local filesystem.
-    write_to_stdout: bool,
-    // What level of logs to output
-    log_level: String,
-    // Username for singing into a private registry
-    username: String,
-    // Password for signing into a private registry
-    password: String,
-    // Force a pull even if the image is present locally
-    force_pull: bool,
-    // Specify a custom socket to utilize for the runtime
-    socket: String,
-}
-
-pub fn get_args() -> Result<Config> {
-    let matches = App::new("dcp")
-        .version(VERSION)
-        .author("exdx")
-        .about("docker cp made easy")
-        .arg(
-            Arg::with_name("image")
-                .value_name("IMAGE")
-                .help("Container image to extract content from")
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("download-path")
-                .value_name("DOWNLOAD-PATH")
-                .help("Where the image contents should be saved on the filesystem")
-                .default_value(".")
-                .short("d")
-                .long("download-path"),
-        )
-        .arg(
-            Arg::with_name("content-path")
-                .value_name("CONTENT-PATH")
-                .help("Where in the container filesystem the content to extract is")
-                .short("c")
-                .default_value("/")
-                .long("content-path"),
-        )
-        .arg(
-            Arg::with_name("write-to-stdout")
-                .value_name("WRITE-TO-STDOUT")
-                .help("Whether to write to stdout instead of the filesystem")
-                .takes_value(false)
-                .short("w")
-                .long("write-to-stdout"),
-        )
-        .arg(
-            Arg::with_name("username")
-                .value_name("USERNAME")
-                .help("Username used for singing into a private registry.")
-                .short("u")
-                .long("username")
-                .default_value(""),
-
-        )
-        .arg(
-            Arg::with_name("password")
-                .value_name("PASSWORD")
-                .help("Password used for signing into a private registry. * WARNING *: Writing credentials to your terminal is risky. Be sure you are okay with them showing up in your history")
-                .short("p")
-                .long("password")
-                .default_value(""),
-
-        )
-        .arg(
-            Arg::with_name("log-level")
-                .value_name("LOG-LEVEL")
-                .help("What level of logs to output. Accepts: [info, debug, trace, error, warn]")
-                .short("l")
-                .long("log-level")
-                .default_value("debug"),
-        )
-        .arg(
-            Arg::with_name("force-pull")
-                .value_name("FORCE-PULL")
-                .help("Force a pull even if the image is present locally")
-                .takes_value(false)
-                .long("force-pull")
-                .short("f")
-        )
-        .arg(
-            Arg::with_name("socket")
-                .value_name("SOCKET")
-                .help("Specify a custom socket to utilize for the runtime")
-                .long("socket")
-                .short("s")
-                .default_value(runtime::DEFAULT_SOCKET)
-        )
-        .get_matches();
-
-    let image = matches.value_of("image").unwrap().to_string();
-    let download_path = matches.value_of("download-path").unwrap().to_string();
-    let content_path = matches.value_of("content-path").unwrap().to_string();
-    let write_to_stdout = matches.is_present("write-to-stdout");
-    let force_pull = matches.is_present("force-pull");
-    let log_level = matches.value_of("log-level").unwrap().to_string();
-    let socket = matches.value_of("socket").unwrap().to_string();
-    // TODO (tyslaton): Need to come up with a way for this to be extracted from the docker config to be more secure locally.
-    let username = matches.value_of("username").unwrap().to_string();
-    let password = matches.value_of("password").unwrap().to_string();
-
-    if write_to_stdout {
-        return Err(anyhow!(
-            "❌ error: writing to stdout is not currently implemented"
-        ));
-    };
-
-    Ok(Config {
-        image,
-        download_path,
-        content_path,
-        write_to_stdout,
-        log_level,
-        username,
-        password,
-        force_pull,
-        socket,
-    })
-}
 
 /// Run runs a sequence of events with the provided image
 /// Run supports copying container filesystems running on both the docker and podman runtimes
@@ -146,20 +13,20 @@ pub fn get_args() -> Result<Config> {
 /// 2. Create a container, receiving the container id as a response
 /// 3. Copy the container content to the specified directory
 /// 4. Delete the container
-pub async fn run(config: Config) -> Result<()> {
+pub async fn run(cfg: config::Config) -> Result<()> {
     pretty_env_logger::formatted_builder()
-        .parse_filters(&config.log_level.clone())
+        .parse_filters(&cfg.log_level.clone())
         .init();
 
     // Build the runtime
-    let rt = if let Some(runtime) = runtime::set(&config.socket).await {
+    let rt = if let Some(runtime) = runtime::set(&cfg.socket).await {
         runtime
     } else {
         return Err(anyhow!("❌ no valid container runtime"));
     };
 
     // Build the image struct
-    let container = match runtime::container::new(config.image, rt) {
+    let container = match runtime::container::new(cfg.image, rt) {
         Ok(i) => i,
         Err(e) => {
             return Err(anyhow!("❌ error building the image: {}", e));
@@ -168,7 +35,7 @@ pub async fn run(config: Config) -> Result<()> {
 
     // Pull the image
     match container
-        .pull(config.username, config.password, config.force_pull)
+        .pull(cfg.username, cfg.password, cfg.force_pull)
         .await
     {
         Ok(_) => {}
@@ -179,11 +46,7 @@ pub async fn run(config: Config) -> Result<()> {
 
     // Copy files from the image
     match container
-        .copy_files(
-            config.content_path,
-            config.download_path,
-            config.write_to_stdout,
-        )
+        .copy_files(cfg.content_path, cfg.download_path, cfg.write_to_stdout)
         .await
     {
         Ok(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate log;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    match dcp::get_args() {
+    match dcp::config::get_args() {
         Err(e) => {
             error!("❌ error reading arguments {}", e);
             std::process::exit(1)

--- a/src/runtime/docker.rs
+++ b/src/runtime/docker.rs
@@ -146,6 +146,7 @@ impl Container for Image {
         Ok(())
     }
 
+    // present_locally determines if this container's image is pulled locally
     async fn present_locally(&self) -> bool {
         debug!("📦 Searching for image {} locally", self.image);
         match self.runtime.images().list(&Default::default()).await {

--- a/src/runtime/podman.rs
+++ b/src/runtime/podman.rs
@@ -138,6 +138,7 @@ impl Container for Image {
         Ok(())
     }
 
+    // present_locally determines if this container's image is pulled locally
     async fn present_locally(&self) -> bool {
         debug!("📦 Searching for image {} locally", self.image);
         match self.runtime.images().list(&Default::default()).await {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use dcp::VERSION;
+use dcp::config::VERSION;
 use predicates::prelude::*;
 use rand::{thread_rng, Rng};
 use std::error::Error;


### PR DESCRIPTION
Breaking out the `Config` struct into its own file to reduce the amount of code in `lib.rs` to just `run()`. This will make it a nicer experience when having to edit the core application logic (`run()`) or the input it accepts (`Config`).