### PR TITLE
test: move test_runs directory to be in target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 .idea
 
-test_runs/
-
 .DS_Store
 
 release.sh

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::fs::remove_dir_all;
 
 const PRG: &str = "dcp";
-const TEST_CONTENT_DIR: &str = "./test_runs";
+const TEST_CONTENT_DIR: &str = "./target/tmp/test_runs";
 const DEFAULT_IMAGE: &str = "quay.io/tyslaton/sample-catalog:v0.0.4";
 const IMAGE_NO_TAG: &str = "quay.io/tyslaton/sample-catalog";
 const SCRATCH_BASE_IMAGE: &str = "quay.io/tflannag/bundles:resolveset-v0.0.2";


### PR DESCRIPTION
Making a slight change to the tests to run write the run artifacts into target so that generated temporary Rust files exist in a single place.